### PR TITLE
Code base cleanup o clock

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ __tests__
 android
 ios
 www
+build

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,12 +9,12 @@ import {Plugins} from '@capacitor/core';
 import {loadFromESASubmissions} from './services/EventService';
 import {IRun} from './services/ScheduleService';
 import {
-  GetBookmark,
-  GetBookmarks,
+  getBookmark,
+  getBookmarks,
   IBookmark,
-  IsBookmarked,
-  RemoveBookmark,
-  StoreBookmark,
+  isBookmarked,
+  removeBookmark,
+  storeBookmark,
 } from './services/BookmarkService';
 import {usePersistent} from './hooks/usePersistent';
 import MenuBar from './components/MenuBar';
@@ -83,7 +83,7 @@ function App() {
   const {error, data: events, isValidating} = useSWR('/events', loadFromESASubmissions);
   const [selectedEventID, setSelectedEvent] = usePersistent<string | undefined>('preferred_event');
   const [bookmarkContext, setBookmarkContext] = useState<IBookmarkContext>(() => ({
-    bookmarks: GetBookmarks(),
+    bookmarks: getBookmarks(),
     onBookmark,
   }));
 
@@ -93,11 +93,10 @@ function App() {
       return;
     }
 
-    const isBookmarked = IsBookmarked(run.id);
-    if (isBookmarked) {
-      RemoveBookmark(run.id);
+    if (isBookmarked(run.id)) {
+      removeBookmark(run.id);
 
-      const bookmark = GetBookmark(run.id);
+      const bookmark = getBookmark(run.id);
       if (bookmark) {
         await cancelNotification(bookmark.notificationId);
       }
@@ -108,12 +107,12 @@ function App() {
         scheduled: dayjs(run.scheduled).subtract(1, 'hour').toDate(),
       });
 
-      StoreBookmark({run, notificationId: notifications[0].id});
+      storeBookmark({run, notificationId: notifications[0].id});
     }
 
     setBookmarkContext((value) => ({
       ...value,
-      bookmarks: GetBookmarks(),
+      bookmarks: getBookmarks(),
     }));
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,30 @@
-import React, {useEffect} from 'react';
+import React, {createContext, useEffect, useState} from 'react';
 import {Redirect, Route} from 'react-router-dom';
 import {ThemeProvider} from 'styled-components';
+import useSWR from 'swr';
+import dayjs from 'dayjs';
 import {IonApp, IonRouterOutlet, IonSplitPane} from '@ionic/react';
 import {IonReactRouter} from '@ionic/react-router';
-import useSWR from 'swr';
 import {Plugins} from '@capacitor/core';
 import {loadFromESASubmissions} from './services/EventService';
+import {IRun} from './services/ScheduleService';
+import {
+  GetBookmark,
+  GetBookmarks,
+  IBookmark,
+  IsBookmarked,
+  RemoveBookmark,
+  StoreBookmark,
+} from './services/BookmarkService';
 import {usePersistent} from './hooks/usePersistent';
 import MenuBar from './components/MenuBar';
+import {cancelNotification, scheduleNotification} from './providers/PushProvider';
 import HomePage from './pages/HomePage';
 import LoadingPage from './pages/LoadingPage';
 import EventPickerPage from './pages/EventPickerPage';
 import SchedulePage from './pages/SchedulePage';
 import BookmarkPage from './pages/BookmarksPage';
+
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
 
@@ -30,7 +42,6 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /* Theme variables */
-
 import './theme/variables.css';
 
 const Themes = {
@@ -61,9 +72,50 @@ const Themes = {
   },
 } as const;
 
+export interface IBookmarkContext {
+  bookmarks: Map<string, IBookmark>;
+  onBookmark: (run: IRun) => void;
+}
+
+export const BookmarkContext = createContext<IBookmarkContext | null>(null);
+
 function App() {
   const {error, data: events, isValidating} = useSWR('/events', loadFromESASubmissions);
   const [selectedEventID, setSelectedEvent] = usePersistent<string | undefined>('preferred_event');
+  const [bookmarkContext, setBookmarkContext] = useState<IBookmarkContext>(() => ({
+    bookmarks: GetBookmarks(),
+    onBookmark,
+  }));
+
+  async function onBookmark(run: IRun) {
+    if (!run.id) {
+      console.warn('Trying to bookmark a run without an ID');
+      return;
+    }
+
+    const isBookmarked = IsBookmarked(run.id);
+    if (isBookmarked) {
+      RemoveBookmark(run.id);
+
+      const bookmark = GetBookmark(run.id);
+      if (bookmark) {
+        await cancelNotification(bookmark.notificationId);
+      }
+    } else {
+      const {notifications} = await scheduleNotification({
+        title: 'Your run is about to start!',
+        body: `In about an hour ${run.game} - ${run.category} starts`,
+        scheduled: dayjs(run.scheduled).subtract(1, 'hour').toDate(),
+      });
+
+      StoreBookmark({run, notificationId: notifications[0].id});
+    }
+
+    setBookmarkContext((value) => ({
+      ...value,
+      bookmarks: GetBookmarks(),
+    }));
+  }
 
   useEffect(() => {
     Plugins.SplashScreen.hide();
@@ -97,25 +149,27 @@ function App() {
 
   return (
     <ThemeProvider theme={theme}>
-      <IonApp>
-        <IonReactRouter>
-          <IonSplitPane contentId="main">
-            <MenuBar event={selectedEvent} onClearEvent={() => setSelectedEvent(undefined)} />
-            <IonRouterOutlet id="main">
-              <Route
-                path="/home"
-                render={(props) => <HomePage {...props} event={selectedEvent} />}
-              />
-              <Route path="/bookmarks" render={(props) => <BookmarkPage {...props} />} />
-              <Route
-                path="/schedule"
-                render={(props) => <SchedulePage {...props} event={selectedEvent} />}
-              />
-              <Redirect from="/" to="/home" exact />
-            </IonRouterOutlet>
-          </IonSplitPane>
-        </IonReactRouter>
-      </IonApp>
+      <BookmarkContext.Provider value={bookmarkContext}>
+        <IonApp>
+          <IonReactRouter>
+            <IonSplitPane contentId="main">
+              <MenuBar event={selectedEvent} onClearEvent={() => setSelectedEvent(undefined)} />
+              <IonRouterOutlet id="main">
+                <Route
+                  path="/home"
+                  render={(props) => <HomePage {...props} event={selectedEvent} />}
+                />
+                <Route path="/bookmarks" render={(props) => <BookmarkPage {...props} />} />
+                <Route
+                  path="/schedule"
+                  render={(props) => <SchedulePage {...props} event={selectedEvent} />}
+                />
+                <Redirect from="/" to="/home" exact />
+              </IonRouterOutlet>
+            </IonSplitPane>
+          </IonReactRouter>
+        </IonApp>
+      </BookmarkContext.Provider>
     </ThemeProvider>
   );
 }

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -163,10 +163,10 @@ function MenuBar({event, onClearEvent}: IProps) {
               ) : null}
               <StyledDateLocation>
                 {event.meta.venue.country ? (
-                  <>
+                  <React.Fragment>
                     <LocationIcon />
                     {event.meta.venue.city || 'yes'}, {event.meta.venue.country || 'Oakland'} |{' '}
-                  </>
+                  </React.Fragment>
                 ) : null}
                 {shortDateRange(event.startDate, event.endDate)}
               </StyledDateLocation>

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -158,9 +158,9 @@ function MenuBar({event, onClearEvent}: IProps) {
             <InnerToolbar>
               <StyledImage src={logoMap[event.meta.theme]} alt="ESA Logo" />
               <StyledTitle>{event.name}</StyledTitle>
-              <StyledParagraph>
-                {event.meta.cause.name ? event.meta.cause.name : 'No Cause have been selected yet'}
-              </StyledParagraph>
+              {event.meta.cause.name ? (
+                <StyledParagraph>{event.meta.cause.name}</StyledParagraph>
+              ) : null}
               <StyledDateLocation>
                 {event.meta.venue.country ? (
                   <>

--- a/src/components/ScheduleCard.tsx
+++ b/src/components/ScheduleCard.tsx
@@ -164,9 +164,7 @@ function ScheduleCard({run}: IProps) {
               <p>{run.category}</p>
             </InnerExpander>
           </Expanded>
-        ) : (
-          <React.Fragment />
-        )}
+        ) : null}
       </Content>
     </Card>
   );

--- a/src/components/ScheduleCard.tsx
+++ b/src/components/ScheduleCard.tsx
@@ -1,16 +1,9 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 import {IRun} from '../services/ScheduleService';
 import {HeartIcon} from '../assets/Icons';
 import dayjs from 'dayjs';
-import {scheduleNotification, cancelNotification} from '../providers/PushProvider';
 import {formatPlayers} from '../services/PlayersService';
-import {
-  StoreBookmark,
-  RemoveBookmark,
-  GetBookmark,
-  IsBookmarked,
-} from '../services/BookmarkService';
 import EstimateParser from './common/EstimateParser';
 
 const Card = styled.li`
@@ -107,39 +100,13 @@ const InnerExpander = styled.div`
 
 interface IProps {
   run: IRun;
+  bookmarked: boolean;
+  onBookmark: (run: IRun) => void;
 }
 
-function ScheduleCard({run}: IProps) {
-  const [bookmarked, setBookmarked] = useState(false);
+function ScheduleCard({run, bookmarked, onBookmark}: IProps) {
   const [expanded, setExpanded] = useState(false);
   const date = dayjs(run.scheduled).format('H:mm A').toUpperCase();
-
-  useEffect(() => {
-    if (IsBookmarked(run.id)) {
-      setBookmarked(true);
-    }
-  }, [run.id]);
-
-  async function bookmarkMe(run: IRun) {
-    setBookmarked(!bookmarked);
-
-    if (!bookmarked) {
-      const {notifications} = await scheduleNotification({
-        title: 'Your run is about to start!',
-        body: `In about an hour ${run.game} - ${run.category} starts`,
-        scheduled: dayjs(run.scheduled).subtract(1, 'hour').toDate(),
-      });
-
-      StoreBookmark({run, notificationId: notifications[0].id});
-    } else {
-      const bookmark = GetBookmark(run.id);
-
-      if (bookmark) {
-        RemoveBookmark(run.id);
-        await cancelNotification(bookmark.notificationId);
-      }
-    }
-  }
 
   async function expandToggle(state: boolean) {
     setExpanded((state = !expanded));
@@ -151,9 +118,11 @@ function ScheduleCard({run}: IProps) {
       <Content>
         <Game>{run.game}</Game>
         <Runner>{formatPlayers(run.players)}</Runner>
-        <HeartButton onClick={() => bookmarkMe(run)}>
-          {bookmarked ? <HeartSymbolLiked /> : <HeartSymbol />}
-        </HeartButton>
+        {run.id ? (
+          <HeartButton onClick={() => onBookmark(run)}>
+            {bookmarked ? <HeartSymbolLiked /> : <HeartSymbol />}
+          </HeartButton>
+        ) : null}
         {expanded ? (
           <Expanded>
             <Expander />

--- a/src/components/ScheduleList.tsx
+++ b/src/components/ScheduleList.tsx
@@ -1,9 +1,10 @@
-import React, {useEffect, useMemo, useRef} from 'react';
+import React, {useContext, useEffect, useMemo, useRef} from 'react';
 import styled from 'styled-components';
 import dayjs from 'dayjs';
 import {GroupedVirtuoso, GroupedVirtuosoHandle} from 'react-virtuoso';
 import ScheduleCard from './ScheduleCard';
 import {IRun} from '../services/ScheduleService';
+import {BookmarkContext, IBookmarkContext} from '../App';
 
 const List = styled.ul`
   display: flex;
@@ -23,11 +24,6 @@ const DayTitle = styled.p`
   margin: 0;
 `;
 
-interface IProps {
-  scrollToDate?: string;
-  schedule: [string, IRun[]][];
-}
-
 function transformGroups(schedule: IProps['schedule']) {
   const groupsCount = schedule.map((runs) => runs[1].length);
   const runs = schedule.flatMap((runs) => runs[1]);
@@ -38,7 +34,13 @@ function transformGroups(schedule: IProps['schedule']) {
   };
 }
 
+interface IProps {
+  scrollToDate?: string;
+  schedule: [string, IRun[]][];
+}
+
 function ScheduleList({scrollToDate, schedule}: IProps) {
+  const {bookmarks, onBookmark} = useContext(BookmarkContext) as IBookmarkContext;
   const virtuoso = useRef<GroupedVirtuosoHandle>(null);
   const {groupsCount, runs} = useMemo(() => transformGroups(schedule), [schedule]);
 
@@ -64,7 +66,13 @@ function ScheduleList({scrollToDate, schedule}: IProps) {
             {dayjs(schedule[index][0]).format('dddd D/M')}
           </DayTitle>
         )}
-        itemContent={(index) => <ScheduleCard run={runs[index]} />}
+        itemContent={(index) => (
+          <ScheduleCard
+            run={runs[index]}
+            bookmarked={!!runs[index].id && bookmarks.has(runs[index].id)}
+            onBookmark={() => runs[index].id && onBookmark(runs[index])}
+          />
+        )}
       />
     </List>
   );

--- a/src/components/common/EstimateParser.tsx
+++ b/src/components/common/EstimateParser.tsx
@@ -6,7 +6,7 @@ interface IProps {
 
 function EstimateParser({seconds}: IProps) {
   const parsedTimer = new window.Date(seconds * 1000).toISOString().substr(11, 8);
-  return <React.Fragment>{parsedTimer}</React.Fragment>;
+  return <>{parsedTimer}</>;
 }
 
 export default EstimateParser;

--- a/src/components/common/EstimateParser.tsx
+++ b/src/components/common/EstimateParser.tsx
@@ -6,7 +6,7 @@ interface IProps {
 
 function EstimateParser({seconds}: IProps) {
   const parsedTimer = new window.Date(seconds * 1000).toISOString().substr(11, 8);
-  return <>{parsedTimer}</>;
+  return <React.Fragment>{parsedTimer}</React.Fragment>;
 }
 
 export default EstimateParser;

--- a/src/hooks/useHomePageGesture.ts
+++ b/src/hooks/useHomePageGesture.ts
@@ -107,12 +107,12 @@ export function useHomePageGesture() {
           return memo;
         }
 
-        memo = value.getValue() - movementY;
+        memo = (value.getValue() as number) - movementY;
       }
 
       // On drag end
       if (last) {
-        const projectedEndpoint = value.getValue() + projection(velocityY);
+        const projectedEndpoint = (value.getValue() as number) + projection(velocityY);
         const point = findNearestNumberInArray(projectedEndpoint, stops);
 
         set(

--- a/src/pages/BookmarksPage.tsx
+++ b/src/pages/BookmarksPage.tsx
@@ -35,9 +35,13 @@ function BookmarkPage({location}: RouteComponentProps) {
       </StyledHeaderWrapper>
       <Content>
         <ScheduleList>
-          {bookmarks.map(({run}) => (
-            <ScheduleCard key={run.scheduled + (run.players.join('-') || '')} run={run} />
-          ))}
+          {bookmarks.length === 0 ? (
+            <p>You don't have any bookmarks yet. Go to the schedule and favorite some!</p>
+          ) : (
+            bookmarks.map(({run}) => (
+              <ScheduleCard key={run.scheduled + (run.players.join('-') || '')} run={run} />
+            ))
+          )}
         </ScheduleList>
       </Content>
     </IonPage>

--- a/src/pages/BookmarksPage.tsx
+++ b/src/pages/BookmarksPage.tsx
@@ -32,7 +32,7 @@ function BookmarkPage(_: RouteComponentProps) {
       <Content>
         <ScheduleList>
           {bookmarks.size === 0 ? (
-            <p>You don't have any bookmarks yet. Go to the schedule and favorite some!</p>
+            <p>You don't have any bookmarks yet. Go to the schedule and mark some!</p>
           ) : (
             Array.from(bookmarks.values()).map(({run}) => (
               <ScheduleCard

--- a/src/pages/BookmarksPage.tsx
+++ b/src/pages/BookmarksPage.tsx
@@ -1,11 +1,11 @@
-import React, {useState, useEffect} from 'react';
+import React, {useContext} from 'react';
 import {IonContent, IonPage} from '@ionic/react';
 import {RouteComponentProps} from 'react-router';
 import styled from 'styled-components';
 import {StyledHeaderWrapper, StyledHeaderSmall} from '../components/common/HeaderBar';
 import Toolbar from '../components/Toolbar';
 import ScheduleCard from '../components/ScheduleCard';
-import {GetBookmarks, IBookmark} from '../services/BookmarkService';
+import {BookmarkContext, IBookmarkContext} from '../App';
 
 const Content = styled(IonContent)`
   background-color: var(--ion-background);
@@ -19,12 +19,8 @@ const ScheduleList = styled.ul`
   overflow-x: scroll;
 `;
 
-function BookmarkPage({location}: RouteComponentProps) {
-  const [bookmarks, setBookmarks] = useState<IBookmark[]>([]);
-
-  useEffect(() => {
-    setBookmarks(GetBookmarks());
-  }, [location.pathname]);
+function BookmarkPage(_: RouteComponentProps) {
+  const {bookmarks, onBookmark} = useContext(BookmarkContext) as IBookmarkContext;
 
   return (
     <IonPage>
@@ -35,11 +31,16 @@ function BookmarkPage({location}: RouteComponentProps) {
       </StyledHeaderWrapper>
       <Content>
         <ScheduleList>
-          {bookmarks.length === 0 ? (
+          {bookmarks.size === 0 ? (
             <p>You don't have any bookmarks yet. Go to the schedule and favorite some!</p>
           ) : (
-            bookmarks.map(({run}) => (
-              <ScheduleCard key={run.scheduled + (run.players.join('-') || '')} run={run} />
+            Array.from(bookmarks.values()).map(({run}) => (
+              <ScheduleCard
+                key={run.scheduled + (run.players.join('-') || '')}
+                run={run}
+                bookmarked
+                onBookmark={() => onBookmark(run)}
+              />
             ))
           )}
         </ScheduleList>

--- a/src/pages/EventPickerPage.tsx
+++ b/src/pages/EventPickerPage.tsx
@@ -64,8 +64,8 @@ function EventPickerPage({events, onPickEvent}: IProps) {
             .filter(
               (event) =>
                 // uncomment next line for debugging old events
-                true ||
-                (dayjs(event.endDate).isAfter(dayjs()) && !blackListedEvents.has(event._id)),
+                // true ||
+                dayjs(event.endDate).isAfter(dayjs()) && !blackListedEvents.has(event._id),
             )
             .map((event) => (
               <Event key={event._id} onClick={() => onPickEvent(event)}>

--- a/src/pages/EventPickerPage.tsx
+++ b/src/pages/EventPickerPage.tsx
@@ -49,6 +49,8 @@ interface IProps {
   onPickEvent: (event: IEvent) => void;
 }
 
+const blackListedEvents = new Set(['2a2819283ae92585552adde0']);
+
 function EventPickerPage({events, onPickEvent}: IProps) {
   return (
     <Page>
@@ -56,15 +58,20 @@ function EventPickerPage({events, onPickEvent}: IProps) {
         <Logo size={120} />
       </LogoWrapper>
       <Title>Pick Event</Title>
-      {events ? (
+      {events.length ? (
         <EventWrapper>
-          {events.map((event) =>
-            dayjs(event.endDate).isAfter(dayjs()) && event._id !== '2a2819283ae92585552adde0' ? (
+          {events
+            .filter(
+              (event) =>
+                // uncomment next line for debugging old events
+                true ||
+                (dayjs(event.endDate).isAfter(dayjs()) && !blackListedEvents.has(event._id)),
+            )
+            .map((event) => (
               <Event key={event._id} onClick={() => onPickEvent(event)}>
                 <span>{event.name}</span>
               </Event>
-            ) : null,
-          )}
+            ))}
         </EventWrapper>
       ) : (
         <p>No Events</p>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useContext, useEffect} from 'react';
 import {IonContent, IonPage, IonRow, IonCol, IonGrid, IonSpinner} from '@ionic/react';
 import {BackButtonEvent} from '@ionic/core';
 import styled from 'styled-components';
@@ -18,6 +18,7 @@ import LiveNow from '../components/LiveNow';
 import {StyledHeaderFull, StyledHeaderWrapper} from '../components/common/HeaderBar';
 import dayjs from 'dayjs';
 import {Plugins} from '@capacitor/core';
+import {BookmarkContext, IBookmarkContext} from '../App';
 
 const {App} = Plugins;
 
@@ -112,6 +113,7 @@ interface IProps {
 }
 
 function HomePage({event}: IProps & RouteComponentProps) {
+  const {bookmarks, onBookmark} = useContext(BookmarkContext) as IBookmarkContext;
   const {data, error, isValidating} = useSWR(
     event.meta.horaro ? `upcoming/${encodeURIComponent(event.meta.horaro)}?amount=5` : null,
     (path: string) => loadFromHoraro<IUpcomingResponse>(path),
@@ -263,7 +265,12 @@ function HomePage({event}: IProps & RouteComponentProps) {
                 </PageHeaderContainer>
                 <ScheduleList>
                   {upNext.map((run) => (
-                    <ScheduleCard key={run.scheduled + run.players.join('')} run={run} />
+                    <ScheduleCard
+                      key={run.scheduled + run.players.join('')}
+                      run={run}
+                      bookmarked={!!run.id && bookmarks.has(run.id)}
+                      onBookmark={() => onBookmark(run)}
+                    />
                   ))}
                 </ScheduleList>
               </>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {IonContent, IonPage, IonRow, IonCol, IonGrid, IonSpinner} from '@ionic/react';
 import {BackButtonEvent} from '@ionic/core';
 import styled from 'styled-components';
@@ -6,7 +6,7 @@ import {Link, RouteComponentProps, useLocation} from 'react-router-dom';
 import {animated} from 'react-spring';
 import useSWR from 'swr';
 import {longDateRange, shortDateRange} from '../services/DateFormatService';
-import {LoadHoraro} from '../services/ScheduleService';
+import {IUpcomingResponse, loadFromHoraro} from '../services/ScheduleService';
 import {useHomePageGesture} from '../hooks/useHomePageGesture';
 import ScheduleCard from '../components/ScheduleCard';
 import HeaderMetaRow from '../components/HeaderMetaRow';
@@ -112,21 +112,32 @@ interface IProps {
 }
 
 function HomePage({event}: IProps & RouteComponentProps) {
-  const {data, isValidating} = useSWR(['homePage:schedule', event.meta.horaro], LoadHoraro);
+  const {data, error, isValidating} = useSWR(
+    event.meta.horaro ? `upcoming/${encodeURIComponent(event.meta.horaro)}?amount=5` : null,
+    (path: string) => loadFromHoraro<IUpcomingResponse>(path),
+  );
   const {animatedValue, bind, stops} = useHomePageGesture();
   const location = useLocation();
 
   const eventIsOver = dayjs().isAfter(event.endDate);
-  const liveNow = data?.data[0];
-  const upNext = data?.data.slice(1);
+  const liveNow = data?.data?.[0];
+  const upNext = data?.data?.slice(1);
 
-  document.addEventListener('ionBackButton', (e) => {
-    (e as BackButtonEvent).detail.register(-1, () => {
-      const path = location.pathname;
-      if (path === '/home') {
-        App.exitApp();
-      }
-    });
+  useEffect(() => {
+    function onBackButton(event: BackButtonEvent) {
+      event.detail.register(-1, () => {
+        const path = location.pathname;
+        if (path === '/home') {
+          App.exitApp();
+        }
+      });
+    }
+
+    document.addEventListener('ionBackButton', onBackButton as EventListener);
+
+    return () => {
+      document.removeEventListener('ionBackButton', onBackButton as EventListener);
+    };
   });
 
   return (
@@ -152,12 +163,12 @@ function HomePage({event}: IProps & RouteComponentProps) {
                 <IonCol size="12" className="ion-align-self-start ion-text-center">
                   <SomeDiv>
                     {event.meta.venue.country ? (
-                      <React.Fragment>
+                      <>
                         <LocationIcon />
                         <Paragraph>
                           {event.meta.venue.city}, {event.meta.venue.country} |
                         </Paragraph>
-                      </React.Fragment>
+                      </>
                     ) : null}
                     <ShortDate>{shortDateRange(event.startDate, event.endDate)}</ShortDate>
                   </SomeDiv>
@@ -185,9 +196,7 @@ function HomePage({event}: IProps & RouteComponentProps) {
                   title="Location"
                   content={`${event.meta.venue.name} in ${event.meta.venue.city}, ${event.meta.venue.country}`}
                 />
-              ) : (
-                <React.Fragment />
-              )}
+              ) : null}
               <HeaderMetaRow
                 title="Stream"
                 content={`twitch.tv/${event.meta.twitchChannel}`}
@@ -209,7 +218,7 @@ function HomePage({event}: IProps & RouteComponentProps) {
       </StyledHeaderWrapper>
 
       <Content>
-        {!data || isValidating ? (
+        {isValidating ? (
           <div
             style={{
               height: '100%',
@@ -220,24 +229,32 @@ function HomePage({event}: IProps & RouteComponentProps) {
           >
             <IonSpinner />
           </div>
+        ) : error ? (
+          <ScheduleList>
+            <p>Could not fetch scheduled runs</p>
+          </ScheduleList>
+        ) : !data ? (
+          <ScheduleList>
+            <p>No runs scheduled yet. Stay tuned!</p>
+          </ScheduleList>
         ) : eventIsOver ? (
           <ScheduleList>
             <p>Event is over</p>
           </ScheduleList>
         ) : (
-          <React.Fragment>
+          <>
             {liveNow ? (
-              <React.Fragment>
+              <>
                 <PageHeaderContainer className="ion-align-items-center ion-justify-content-between">
                   <Title>Live Now</Title>
                 </PageHeaderContainer>
                 <ScheduleList>
                   <LiveNow run={liveNow} />
                 </ScheduleList>
-              </React.Fragment>
+              </>
             ) : null}
             {upNext ? (
-              <React.Fragment>
+              <>
                 <PageHeaderContainer className="ion-align-items-center ion-justify-content-between">
                   <Title>Up Next</Title>
                   <StyledLink to="schedule">
@@ -249,9 +266,9 @@ function HomePage({event}: IProps & RouteComponentProps) {
                     <ScheduleCard key={run.scheduled + run.players.join('')} run={run} />
                   ))}
                 </ScheduleList>
-              </React.Fragment>
+              </>
             ) : null}
-          </React.Fragment>
+          </>
         )}
       </Content>
     </IonPage>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -165,12 +165,12 @@ function HomePage({event}: IProps & RouteComponentProps) {
                 <IonCol size="12" className="ion-align-self-start ion-text-center">
                   <SomeDiv>
                     {event.meta.venue.country ? (
-                      <>
+                      <React.Fragment>
                         <LocationIcon />
                         <Paragraph>
                           {event.meta.venue.city}, {event.meta.venue.country} |
                         </Paragraph>
-                      </>
+                      </React.Fragment>
                     ) : null}
                     <ShortDate>{shortDateRange(event.startDate, event.endDate)}</ShortDate>
                   </SomeDiv>
@@ -244,19 +244,19 @@ function HomePage({event}: IProps & RouteComponentProps) {
             <p>Event is over</p>
           </ScheduleList>
         ) : (
-          <>
+          <React.Fragment>
             {liveNow ? (
-              <>
+              <React.Fragment>
                 <PageHeaderContainer className="ion-align-items-center ion-justify-content-between">
                   <Title>Live Now</Title>
                 </PageHeaderContainer>
                 <ScheduleList>
                   <LiveNow run={liveNow} />
                 </ScheduleList>
-              </>
+              </React.Fragment>
             ) : null}
             {upNext ? (
-              <>
+              <React.Fragment>
                 <PageHeaderContainer className="ion-align-items-center ion-justify-content-between">
                   <Title>Up Next</Title>
                   <StyledLink to="schedule">
@@ -273,9 +273,9 @@ function HomePage({event}: IProps & RouteComponentProps) {
                     />
                   ))}
                 </ScheduleList>
-              </>
+              </React.Fragment>
             ) : null}
-          </>
+          </React.Fragment>
         )}
       </Content>
     </IonPage>

--- a/src/services/AnnouncementsService.ts
+++ b/src/services/AnnouncementsService.ts
@@ -1,6 +1,6 @@
 const baseUrl = 'https://esamarathon.dev/api/news';
 
-export async function LoadAnnouncements(limit: string | undefined) {
-  const response = await fetch(`${baseUrl}?limit=${limit}`);
+export async function loadAnnouncements(limit?: string) {
+  const response = await fetch(`${baseUrl}${limit ? `?limit=${limit}` : ''}`);
   return response.json();
 }

--- a/src/services/BookmarkService.ts
+++ b/src/services/BookmarkService.ts
@@ -5,7 +5,7 @@ export interface IBookmark {
   notificationId: string;
 }
 
-export function GetBookmark(runId: string) {
+export function getBookmark(runId: string) {
   const item = localStorage.getItem(`ESA@notification-${runId}`);
   if (!item) {
     return undefined;
@@ -14,7 +14,7 @@ export function GetBookmark(runId: string) {
   return JSON.parse(item) as IBookmark;
 }
 
-export function GetBookmarks() {
+export function getBookmarks() {
   return Object.keys(localStorage).reduce((bookmarks, key) => {
     if (key.startsWith('ESA@notification-')) {
       const storedNotification = localStorage.getItem(key);
@@ -40,14 +40,14 @@ export function GetBookmarks() {
   }, new Map<string, IBookmark>());
 }
 
-export function StoreBookmark(details: IBookmark) {
+export function storeBookmark(details: IBookmark) {
   localStorage.setItem(`ESA@notification-${details.run.id}`, JSON.stringify(details));
 }
 
-export function IsBookmarked(runId: string) {
+export function isBookmarked(runId: string) {
   return !!localStorage.getItem(`ESA@notification-${runId}`);
 }
 
-export function RemoveBookmark(runId: string) {
+export function removeBookmark(runId: string) {
   localStorage.removeItem(`ESA@notification-${runId}`);
 }

--- a/src/services/EventService.ts
+++ b/src/services/EventService.ts
@@ -1,11 +1,9 @@
 export type EventTheme = 'default' | 'summer' | 'winter';
 
-interface IEventMeta {
-  theme: EventTheme;
-  horaro: string;
-  twitchChannel: string;
-  cause: IEventCause;
-  venue: IEventVenue;
+interface IEventCause {
+  name: string;
+  link: string;
+  logo: string;
 }
 
 interface IEventVenue {
@@ -15,10 +13,12 @@ interface IEventVenue {
   name: string;
 }
 
-interface IEventCause {
-  name: string;
-  link: string;
-  logo: string;
+interface IEventMeta {
+  theme: EventTheme;
+  horaro: string;
+  twitchChannel: string;
+  cause: IEventCause;
+  venue: IEventVenue;
 }
 
 export interface IEvent {
@@ -38,8 +38,9 @@ export interface IEvent {
   updatedAt: string;
 }
 
-export async function LoadEvents(url: string): Promise<IEvent[]> {
-  const response = await fetch(url);
-
+const baseURL = 'https://api.submissions.esamarathon.com';
+export async function loadFromESASubmissions<T extends IEvent[]>(endpoint: string): Promise<T> {
+  const path = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+  const response = await fetch(`${baseURL}/${path}`);
   return response.json();
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
     ],
-    "allowJs": true,
+    "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
@@ -19,7 +19,6 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx"],
+  "exclude": ["**/node_modules", "**/.*/"],
 }


### PR DESCRIPTION
This turned out bigger than I had hoped and I'm sorry 

## Some things I did:
### Chore:
- Improved performance of ESLint and TypeScript by ignoring more files.

### General:
- Added better data fetching error handling in a few places. Now shows when fetching goes wrong, instead of just a permanent spinner.
- Wrapped some component side-effects in `useEffect`, so it's only called once and not on every rerender.

### Schedule:
- Fix scrolling to specific date (now without hash-links)
- Modified the Virtuoso grouping and data fetching logic to be a bit simpler

### Bookmarking:
- Moved bookmark data to context, because Virtuoso wasn't having a good time with the effects accessing local storage in all the `ScheduleCard`s.
- Disable bookmarking runs with no ID specified, this was breaking the bookmarks as well.

### Themes
- Fix app breaking for events where no theme is set in Horaro.

